### PR TITLE
add support for env args for build dir

### DIFF
--- a/lua/tasks/cmake_presets.lua
+++ b/lua/tasks/cmake_presets.lua
@@ -233,6 +233,10 @@ function presets.get_build_dir(preset)
     build_dir = build_dir:gsub("${dollar}", "$")
     build_dir = build_dir:gsub("${pathListSep}", "/")
 
+    build_dir = build_dir:gsub("%$env{(.-)}", function(env_var)
+        return vim.fn.getenv(env_var) or ""
+    end)
+
     return build_dir
 end
 


### PR DESCRIPTION
This adds support for the expressions like this
```
"binaryDir": "${sourceDir}/$env{BUILD_DIR}",
```